### PR TITLE
feat: Add new `traciraptor`-decorated example functions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-test-deploy:
-    runs-on: ["self-hosted", "Deb13"]
+    # runs-on: ["self-hosted", "Deb13"]
     container:
       image: python:3.13-slim-trixie
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   test:
 
-    runs-on: ["self-hosted", "Deb13"]
+    # runs-on: ["self-hosted", "Deb13"]
 
     strategy:
       fail-fast: true

--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,21 +94,11 @@ select = [
 [tool.ruff.lint.isort]
 known-first-party = ["voltrix"]
 
-[tool.mypy]
-python_version = "3.13"
-strict = true
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_unreachable = true
-strict_equality = true
+[[tool.ty.overrides]]
+include = ["tests/**", "**/test_*.py"]
+
+[tool.ty.overrides.rules]
+possibly-unresolved-reference = "warn"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/voltrix/ali/veli.py
+++ b/src/voltrix/ali/veli.py
@@ -1,6 +1,32 @@
+import time
+
+from voltrix.util import traciraptor
+
+
+@traciraptor
 def print_veli() -> None:
     print("Hello from Veli!")
 
 
+@traciraptor
+def inner_func_1():
+    print("Hello from inner_func_1")
+    time.sleep(1)
+
+
+@traciraptor
+def inner_func_2():
+    print("Hello from inner_func_2")
+    time.sleep(1)
+
+
+@traciraptor
+def outer_func():
+    print("Hello from outer_func")
+    inner_func_1()
+    time.sleep(3)
+    inner_func_2()
+
+
 if __name__ == "__main__":
-    print_veli()
+    outer_func()

--- a/tests/examples/test_polars_examples.py
+++ b/tests/examples/test_polars_examples.py
@@ -41,7 +41,7 @@ def test_filter_large_trades(trades: pl.DataFrame):
         # Calculate value column just for verification
         check_df = filtered.with_columns((pl.col("price") * pl.col("quantity")).alias("value"))
         min_value = check_df["value"].min()
-        assert min_value > threshold
+        assert min_value > threshold  # ty:ignore[unsupported-operator]
 
 
 @given(trades=polars_trades_dataframe())


### PR DESCRIPTION
- ignore `.vscode` directory, and add type ignore comment.
- add ty as typecker and remove mypy
- test traciraptor decorator
- try not to use self hosted cicd for now